### PR TITLE
chore: add Slack CLI support

### DIFF
--- a/.slack/.gitignore
+++ b/.slack/.gitignore
@@ -1,0 +1,2 @@
+apps.dev.json
+cache/

--- a/.slack/hooks.json
+++ b/.slack/hooks.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "get-hooks": "npx -q --no-install -p @slack/cli-hooks slack-cli-get-hooks"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,38 @@ Reacjilator translates a message when a user reacts with an emoji (*"reacji"*). 
 
 ![Reacjilator demo](tutorial_images/reacjilator-demo.gif)
 
-## Set Up Your Slack App
+## Installation
+
+### Using Slack CLI
+
+Install the latest version of the Slack CLI for your operating system:
+
+- [Slack CLI for macOS & Linux](https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-mac-and-linux/)
+- [Slack CLI for Windows](https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-windows/)
+
+You'll also need to log in if this is your first time using the Slack CLI.
+
+```sh
+slack login
+```
+
+#### Initializing the project
+
+```sh
+slack create bolt-js-reacjilator --template slack-samples/bolt-js-reacjilator
+cd bolt-js-reacjilator
+```
+
+#### Running the app
+
+```sh
+slack run
+```
+
+<details>
+<summary><h3>Using Terminal</h3></summary>
+
+#### Set Up Your Slack App
 
 1. Create an app at your Slack App Settings page at [api.slack.com/apps](https://api.slack.com/apps)
 2. Choose "From an app manifest", select the workspace you want to use, then paste the contents of [`manifest.yml`](./manifest.yml) into the dialog marked "Enter app manifest below".
@@ -12,7 +43,7 @@ Reacjilator translates a message when a user reacts with an emoji (*"reacji"*). 
 4. On the **Basic Information** page, scroll down to **App-Level Tokens** and click **Generate Token and Scopes**.
 5. Add the `connections:write` scope, give your token a name, and click **Generate**. Copy this new token to your `.env` file as `SLACK_APP_TOKEN`
 
-### Credentials
+##### Credentials
 
 Rename the `.env.sample` to `.env` and fill the env vars with your credentials. You also need Google credentials to use the Google translation API:
 
@@ -27,3 +58,4 @@ Get Your Slack App-Level Token at **Basic Information**, And your bot token at *
 
 Get your Google Cloud project ID and application credentials at [cloud.google.com](https://cloud.google.com/translate/docs/getting-started)
 
+</details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@google-cloud/translate": "^9.4.2",
         "@slack/bolt": "^4.7.3",
         "dotenv": "^17.4.2"
+      },
+      "devDependencies": {
+        "@slack/cli-hooks": "^2.0.0"
       }
     },
     "node_modules/@google-cloud/common": {
@@ -233,6 +236,28 @@
       },
       "peerDependencies": {
         "@types/express": "^5.0.0"
+      }
+    },
+    "node_modules/@slack/cli-hooks": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/cli-hooks/-/cli-hooks-2.0.0.tgz",
+      "integrity": "sha512-VLxGqJZwbrH3S+ovRhqlrcrKWHRDJtn3toraZKAcLaPqca5CgqTa/PmiCvCq3uUowiFw9B7FOB0y3ikQoDppTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.8",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "slack-cli-check-update": "src/check-update.js",
+        "slack-cli-doctor": "src/doctor.js",
+        "slack-cli-get-hooks": "src/get-hooks.js",
+        "slack-cli-get-manifest": "src/get-manifest.js",
+        "slack-cli-start": "src/start.js"
+      },
+      "engines": {
+        "node": ">= 20",
+        "npm": ">=9.6.4"
       }
     },
     "node_modules/@slack/logger": {
@@ -1766,6 +1791,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "@google-cloud/translate": "^9.4.2",
     "@slack/bolt": "^4.7.3",
     "dotenv": "^17.4.2"
+  },
+  "devDependencies": {
+    "@slack/cli-hooks": "^2.0.0"
   }
 }


### PR DESCRIPTION
This standardizes Slack CLI support for this sample so it can be created and run with the Slack CLI (`slack create` / `slack run`), matching the other CLI-enabled Bolt samples.

Adds (only the pieces this repo was missing):
- `.slack/hooks.json` — the CLI `get-hooks` config
- `.slack/.gitignore` — ignores `apps.dev.json` and `cache/` (local CLI state)
- the CLI hooks dependency (`@slack/cli-hooks` for JS/TS, `slack-cli-hooks==0.3.0` for Python)
- a `### Using Slack CLI` README section, with the existing manual flow preserved under `Using Terminal`

Opened as a **draft** for review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)